### PR TITLE
Fix request url creation

### DIFF
--- a/tortik/page/__init__.py
+++ b/tortik/page/__init__.py
@@ -206,6 +206,10 @@ class RequestHandler(tornado.web.RequestHandler):
         def _on_fetch(response, name):
             content_type = response.headers.get('Content-Type', '').split(';')[0]
             response.data = None
+            self.log.debug(
+                'Got response for "%s" (code = %s, content_type = %s): %s',
+                name, response.code, content_type, response.body,
+            )
             try:
                 if 'xml' in content_type:
                     response.data = parse_xml(response)

--- a/tortik/page/__init__.py
+++ b/tortik/page/__init__.py
@@ -233,7 +233,7 @@ class RequestHandler(tornado.web.RequestHandler):
             self.http_client.fetch(req, ag.add(partial(_on_fetch, name=req.name)))
 
     def make_request(self, name, method='GET', full_url=None, url_prefix=None, path='', data='', headers=None,
-                     connect_timeout=1, request_timeout=2, follow_redirects=True, **kwargs):
+                     connect_timeout=1, request_timeout=2, follow_redirects=True, safe='/,', **kwargs):
         """
         Class for easier constructing ``tornado.httpclient.HTTPRequest`` object.
 
@@ -277,9 +277,9 @@ class RequestHandler(tornado.web.RequestHandler):
         if method in ['GET', 'HEAD', 'DELETE']:
             parsed_query = urlparse.parse_qs(query)
             parsed_query.update(data if isinstance(data, dict) else urlparse.parse_qs(data))
-            query = make_qs(parsed_query)
+            query = make_qs(parsed_query, safe=safe)
         else:
-            body = make_qs(data) if isinstance(data, dict) else data
+            body = make_qs(data, safe=safe) if isinstance(data, dict) else data
 
         headers = {} if headers is None else headers
 

--- a/tortik/page/__init__.py
+++ b/tortik/page/__init__.py
@@ -233,7 +233,7 @@ class RequestHandler(tornado.web.RequestHandler):
             self.http_client.fetch(req, ag.add(partial(_on_fetch, name=req.name)))
 
     def make_request(self, name, method='GET', full_url=None, url_prefix=None, path='', data='', headers=None,
-                     connect_timeout=1, request_timeout=2, follow_redirects=True, safe='/,', **kwargs):
+                     connect_timeout=1, request_timeout=2, follow_redirects=True, safe='/', **kwargs):
         """
         Class for easier constructing ``tornado.httpclient.HTTPRequest`` object.
 

--- a/tortik/page/__init__.py
+++ b/tortik/page/__init__.py
@@ -207,7 +207,7 @@ class RequestHandler(tornado.web.RequestHandler):
             content_type = response.headers.get('Content-Type', '').split(';')[0]
             response.data = None
             self.log.debug(
-                'Got response for "%s" (code = %s, content_type = %s): %s',
+                'Got response for "%s" (code = %s, content_type = %s): %.100s',
                 name, response.code, content_type, response.body,
             )
             try:

--- a/tortik/util/__init__.py
+++ b/tortik/util/__init__.py
@@ -9,9 +9,9 @@ except ImportError:
     import urllib.parse as urlparse  # py3
 
 try:
-    from urllib import urlencode  # py2
-except ImportError:
     from urllib.parse import urlencode  # py3
+except ImportError:
+    from tortik.util.url import urlencode
 
 
 def decorate_all(decorator_list):
@@ -80,13 +80,14 @@ def update_url(url, update_args=None, remove_args=None):
     return urlparse.urlunsplit((scheme, url_split.netloc, url_split.path, query, url_split.fragment))
 
 
-def make_qs(query_args):
-    def _encode(s):
-        if isinstance(s, unicode_type):
-            return s.encode('utf-8')
-        else:
-            return s
+def _encode(s):
+    if isinstance(s, unicode_type):
+        return s.encode('utf-8')
+    else:
+        return s
 
+
+def make_qs(query_args, safe='/,'):
     kv_pairs = []
     for key, val in query_args.items():
         if val is not None:
@@ -97,6 +98,6 @@ def make_qs(query_args):
             else:
                 kv_pairs.append((encoded_key, _encode(val)))
 
-    qs = urlencode(kv_pairs, doseq=True)
+    qs = urlencode(kv_pairs, doseq=True, safe=safe)
 
     return qs

--- a/tortik/util/__init__.py
+++ b/tortik/util/__init__.py
@@ -87,7 +87,7 @@ def _encode(s):
         return s
 
 
-def make_qs(query_args, safe='/,'):
+def make_qs(query_args, safe='/'):
     kv_pairs = []
     for key, val in query_args.items():
         if val is not None:

--- a/tortik/util/url.py
+++ b/tortik/util/url.py
@@ -1,0 +1,72 @@
+import sys
+
+from urllib import quote_plus, _is_unicode
+
+
+def urlencode(query, doseq=0, safe='/'):
+    """Patched py2 version of urlencode - added `safe` parameter (py3 version
+    supports this).
+
+    The original docstring:
+
+    Encode a sequence of two-element tuples or dictionary into a URL query string.
+
+    If any values in the query arg are sequences and doseq is true, each
+    sequence element is converted to a separate parameter.
+
+    If the query arg is a sequence of two-element tuples, the order of the
+    parameters in the output will match the order of parameters in the
+    input.
+    """
+
+    if hasattr(query,"items"):
+        # mapping objects
+        query = query.items()
+    else:
+        # it's a bother at times that strings and string-like objects are
+        # sequences...
+        try:
+            # non-sequence items should not work with len()
+            # non-empty strings will fail this
+            if len(query) and not isinstance(query[0], tuple):
+                raise TypeError
+            # zero-length sequences of all types will get here and succeed,
+            # but that's a minor nit - since the original implementation
+            # allowed empty dicts that type of behavior probably should be
+            # preserved for consistency
+        except TypeError:
+            ty,va,tb = sys.exc_info()
+            raise TypeError, "not a valid non-string sequence or mapping object", tb
+
+    l = []
+    if not doseq:
+        # preserve old behavior
+        for k, v in query:
+            k = quote_plus(str(k), safe=safe)
+            v = quote_plus(str(v), safe=safe)
+            l.append(k + '=' + v)
+    else:
+        for k, v in query:
+            k = quote_plus(str(k), safe=safe)
+            if isinstance(v, str):
+                v = quote_plus(v, safe=safe)
+                l.append(k + '=' + v)
+            elif _is_unicode(v):
+                # is there a reasonable way to convert to ASCII?
+                # encode generates a string, but "replace" or "ignore"
+                # lose information and "strict" can raise UnicodeError
+                v = quote_plus(v.encode("ASCII","replace"), safe=safe)
+                l.append(k + '=' + v)
+            else:
+                try:
+                    # is this a sufficient test for sequence-ness?
+                    len(v)
+                except TypeError:
+                    # not a sequence
+                    v = quote_plus(str(v), safe=safe)
+                    l.append(k + '=' + v)
+                else:
+                    # loop over the sequence
+                    for elt in v:
+                        l.append(k + '=' + quote_plus(str(elt), safe=safe))
+    return '&'.join(l)

--- a/tortik_tests/util_test.py
+++ b/tortik_tests/util_test.py
@@ -75,7 +75,7 @@ class TestMakeQs(BaseTest):
         self.assertQueriesEqual(make_qs(query_args, '/,'), 'a=1,2,3&b=asd')
 
     def test_make_qs_comma_quoted(self):
-        # default value for `safe` parameter of make_qs is '/,' so commas
+        # default value for `safe` parameter of make_qs is '/' so commas
         # should be encoded
         query_args = {'a': '1,2,3', 'b': 'asd'}
         self.assertQueriesEqual(make_qs(query_args), 'a=1%2C2%2C3&b=asd')

--- a/tortik_tests/util_test.py
+++ b/tortik_tests/util_test.py
@@ -71,14 +71,14 @@ class TestMakeQs(BaseTest):
         )
 
     def test_make_qs_comma(self):
-        # default value for `safe` parameter of make_qs is '/,' so commas
-        # should not be encoded
         query_args = {'a': '1,2,3', 'b': 'asd'}
-        self.assertQueriesEqual(make_qs(query_args), 'a=1,2,3&b=asd')
+        self.assertQueriesEqual(make_qs(query_args, '/,'), 'a=1,2,3&b=asd')
 
     def test_make_qs_comma_quoted(self):
+        # default value for `safe` parameter of make_qs is '/,' so commas
+        # should be encoded
         query_args = {'a': '1,2,3', 'b': 'asd'}
-        self.assertQueriesEqual(make_qs(query_args, safe='/'), 'a=1%2C2%2C3&b=asd')
+        self.assertQueriesEqual(make_qs(query_args), 'a=1%2C2%2C3&b=asd')
 
 
 class TestUpdateUrl(BaseTest):

--- a/tortik_tests/util_test.py
+++ b/tortik_tests/util_test.py
@@ -70,6 +70,16 @@ class TestMakeQs(BaseTest):
             '%D0%BF%D1%80%D0%B8=%D0%B2%D0%B5%D1%82&%D0%BF%D0%BE=%D0%BA%D0%B0'
         )
 
+    def test_make_qs_comma(self):
+        # default value for `safe` parameter of make_qs is '/,' so commas
+        # should not be encoded
+        query_args = {'a': '1,2,3', 'b': 'asd'}
+        self.assertQueriesEqual(make_qs(query_args), 'a=1,2,3&b=asd')
+
+    def test_make_qs_comma_quoted(self):
+        query_args = {'a': '1,2,3', 'b': 'asd'}
+        self.assertQueriesEqual(make_qs(query_args, safe='/'), 'a=1%2C2%2C3&b=asd')
+
 
 class TestUpdateUrl(BaseTest):
     def test_simple(self):


### PR DESCRIPTION
The patch is to allow to pass `safe` parameter (see python3 docs for https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote) to make_request. The default value for make_request is the same as the defaults in python standard library (`/`).
The PR will allow, for example, to work with APIs that require not-encoded commas in query strings (like `some_parameter=1,2,3`).