### PR TITLE
[DEV-10280] Корректно логировать

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-tortik (0.2.11) unstable; urgency=low
+
+   * better logging
+
+  -- Nikita Kotov <kotov@huntflow.ru>  Wed, 29 Mar 2023 11:30:00 +0300
+
 python-tortik (0.2.10) unstable; urgency=low
 
    * сhanged x-forwarded-for headers ordering

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,8 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
-primary_domain = 'py'
-default_role = 'py:obj'
+primary_domain = "py"
+default_role = "py:obj"
 
 autodoc_member_order = "bysource"
 autoclass_content = "both"
@@ -34,22 +34,23 @@ autoclass_content = "both"
 autodoc_docstring_signature = False
 
 coverage_skip_undoc_in_source = True
-coverage_ignore_modules = [
-
-]
+coverage_ignore_modules = []
 # I wish this could go in a per-module file...
-coverage_ignore_classes = [
+coverage_ignore_classes = []
 
-]
+coverage_ignore_functions = []
 
-coverage_ignore_functions = [
-
-]
-
-html_favicon = 'favicon.ico'
+html_favicon = "favicon.ico"
 
 latex_documents = [
-    ('index', 'tortik.tex', 'Tortik Documentation', 'The Tortik Authors', 'manual', False),
+    (
+        "index",
+        "tortik.tex",
+        "Tortik Documentation",
+        "The Tortik Authors",
+        "manual",
+        False,
+    ),
 ]
 
 # HACK: sphinx has limited support for substitutions with the |version|
@@ -59,20 +60,19 @@ latex_documents = [
 # The extlink extension can be used to do link substitutions, but it requires a
 # portion of the url to be literally contained in the document.  Therefore,
 # this link must be referenced as :current_tarball:`z`
-extlinks = {
-
-}
+extlinks = {}
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/2.7/', None),
+    "python": ("https://docs.python.org/2.7/", None),
 }
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 # On RTD we can't import sphinx_rtd_theme, but it will be applied by
 # default anyway.  This block will use the same theme when building locally
 # as on RTD.
 if not on_rtd:
     import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
+
+    html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/examples/hello-world/server.py
+++ b/examples/hello-world/server.py
@@ -15,7 +15,7 @@ from tornado.options import options
 try:
     import tortik
 except ImportError:
-    sys.path.append(path.abspath(path.join(path.dirname(__file__), '..', '..')))
+    sys.path.append(path.abspath(path.join(path.dirname(__file__), "..", "..")))
     import tortik
 
 from tortik.page import RequestHandler
@@ -24,8 +24,8 @@ import tortik.logger
 
 def preprocessor(handler, callback):
     def handle_request():
-        handler.log.info('Log from preprocessor')
-        handler.hello = 'Hello'  # save some data from preprocessor
+        handler.log.info("Log from preprocessor")
+        handler.hello = "Hello"  # save some data from preprocessor
         callback()
 
     IOLoop.instance().add_callback(handle_request)  # emulate async call
@@ -33,34 +33,37 @@ def preprocessor(handler, callback):
 
 def postprocessor(handler, data, callback):
     def handle_request():
-        handler.log.info('Log from postprocessor')
+        handler.log.info("Log from postprocessor")
         added_data = handler.get_data()
-        processed_data = map(lambda x: x.get('header_image'), added_data.get('steam', {}).get('large_capsules', []))
-        callback(handler, {'images': list(processed_data)})
+        processed_data = map(
+            lambda x: x.get("header_image"),
+            added_data.get("steam", {}).get("large_capsules", []),
+        )
+        callback(handler, {"images": list(processed_data)})
 
     IOLoop.instance().add_callback(handle_request)  # emulate async call
 
 
 class MainHandler(RequestHandler):
-    preprocessors = [
-        preprocessor
-    ]
-    postprocessors = [
-        postprocessor
-    ]
+    preprocessors = [preprocessor]
+    postprocessors = [postprocessor]
 
     def get(self):
-        self.fetch_requests([
-            ('steam', 'http://store.steampowered.com/api/featured/'),
-            ('hhapi', 'https://api.hh.ru/dictionaries', {'locale': 'EN'}),
-            ('xml', self.request.protocol + "://" + self.request.host + '/mock/xml')
-        ], callback=self.complete)
+        self.fetch_requests(
+            [
+                ("steam", "http://store.steampowered.com/api/featured/"),
+                ("hhapi", "https://api.hh.ru/dictionaries", {"locale": "EN"}),
+                (
+                    "xml",
+                    self.request.protocol + "://" + self.request.host + "/mock/xml",
+                ),
+            ],
+            callback=self.complete,
+        )
 
 
 class ExceptionHandler(MainHandler):
-    postprocessors = [
-
-    ]
+    postprocessors = []
 
     def get(self):
         test = 1 / 0  # ZeroDivisionError
@@ -69,53 +72,68 @@ class ExceptionHandler(MainHandler):
 class MockXmlHandler(tornado.web.RequestHandler):
     @staticmethod
     def mock_data():
-        fd = open(path.join(path.dirname(__file__), 'simple.xml'), 'r')
+        fd = open(path.join(path.dirname(__file__), "simple.xml"), "r")
         data = fd.read()
         fd.close()
         return data
 
     def get(self):
-        self.set_header('Content-Type', 'application/xml')
+        self.set_header("Content-Type", "application/xml")
         self.finish(self.mock_data())
 
 
 class Application(tornado.web.Application):
     def __init__(self):
         handlers = [
-            (r'/', MainHandler),
-            (r'/exception', ExceptionHandler),
-            (r'/mock/xml', MockXmlHandler),
+            (r"/", MainHandler),
+            (r"/exception", ExceptionHandler),
+            (r"/mock/xml", MockXmlHandler),
         ]
 
         tortik.logger.configure()
         super(Application, self).__init__(handlers)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # some options & options parsing
-    options.define('host', type=str, default='localhost', help='Bind address')
-    options.define('port', type=int, default=8888, help='Bind port')
-    options.parse_config_file(path.join(path.dirname(__file__), 'options.cfg'), final=False)
+    options.define("host", type=str, default="localhost", help="Bind address")
+    options.define("port", type=int, default=8888, help="Bind port")
+    options.parse_config_file(
+        path.join(path.dirname(__file__), "options.cfg"), final=False
+    )
     options.parse_command_line()
 
     # this is how http client could be configured
-    tornado.httpclient.AsyncHTTPClient.configure("tornado.simple_httpclient.SimpleAsyncHTTPClient", defaults={
-        'user_agent': ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/537.1 (KHTML, like Gecko)"
-                       " Chrome/21.0.1180.89 Safari/537.1")
-    })
+    tornado.httpclient.AsyncHTTPClient.configure(
+        "tornado.simple_httpclient.SimpleAsyncHTTPClient",
+        defaults={
+            "user_agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/537.1 (KHTML, like Gecko)"
+                " Chrome/21.0.1180.89 Safari/537.1"
+            )
+        },
+    )
 
     address = options.host
     port = options.port
 
     application = Application()
-    sys.stderr.write(('Start server at {address}:{port}\n'
-                      'See example pages at:\n'
-                      '* http://{address}:{port}/\n'
-                      '* http://{address}:{port}/?debug{p}\n'
-                      '* http://{address}:{port}/exception\n'
-                      '* http://{address}:{port}/exception?debug{p}\n'
-                      ).format(address=options.host, port=options.port,
-                               p=('=' + urllib.quote(options.debug_password)) if options.debug_password else ''))
+    sys.stderr.write(
+        (
+            "Start server at {address}:{port}\n"
+            "See example pages at:\n"
+            "* http://{address}:{port}/\n"
+            "* http://{address}:{port}/?debug{p}\n"
+            "* http://{address}:{port}/exception\n"
+            "* http://{address}:{port}/exception?debug{p}\n"
+        ).format(
+            address=options.host,
+            port=options.port,
+            p=("=" + urllib.quote(options.debug_password))
+            if options.debug_password
+            else "",
+        )
+    )
     application.listen(port, address)
 
     # start ioloop

--- a/setup.py
+++ b/setup.py
@@ -32,18 +32,22 @@ class TestCommand(Command):
 
     def run(self):
         import nose
-        nose.main(argv=['nosetests', 'tortik_tests/'])
+
+        nose.main(argv=["nosetests", "tortik_tests/"])
 
 
 class BuildHook(build_py):
     def run(self):
         build_py.run(self)
 
-        build_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), self.build_lib, 'tortik')
-        with open(os.path.join(build_dir, 'version.py'), 'w') as version_file:
+        build_dir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), self.build_lib, "tortik"
+        )
+        with open(os.path.join(build_dir, "version.py"), "w") as version_file:
             version_file.write('version = "{0}"\n'.format(version))
 
-install_requires = ['tornado==5.1.1', 'MarkupSafe==1.1.0', 'jinja2==2.10', 'six']
+
+install_requires = ["tornado==5.1.1", "MarkupSafe==1.1.0", "jinja2==2.10", "six"]
 
 setup(
     name="tortik",
@@ -51,22 +55,22 @@ setup(
     description="Tortik - python tornado framework",
     long_description=open("README.rst").read(),
     url="https://github.com/glibin/tortik",
-    download_url='https://github.com/glibin/tortik/tarball/{}'.format(version),
-    packages=find_packages(exclude=['tortik_tests', 'tortik_tests.*']),
+    download_url="https://github.com/glibin/tortik/tarball/{}".format(version),
+    packages=find_packages(exclude=["tortik_tests", "tortik_tests.*"]),
     package_data={
         "tortik": find_package_data("tortik", "templates"),
     },
-    cmdclass={'test': TestCommand, 'build_py': BuildHook},
+    cmdclass={"test": TestCommand, "build_py": BuildHook},
     install_requires=install_requires,
-    setup_requires=['nose', 'pep8'],
+    setup_requires=["nose", "pep8"],
     classifiers=[
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
     ],
 )

--- a/tortik/logger.py
+++ b/tortik/logger.py
@@ -68,28 +68,6 @@ class PageLogger(logging.LoggerAdapter):
             kwargs['extra'].update(self.extra)
         return msg, kwargs
 
-    # def cache_access_started(self, cache_name):
-    #     self.debug("Requesting cache {0}".format(cache_name), extra={_SKIP_EVENT: True})
-    #     if self.debug_info is not None:
-    #         self.debug_info[cache_name] = {
-    #             'type': 'cache',
-    #             'started': time.time(),
-    #             'name': cache_name
-    #         }
-    #
-    # def cache_access_complete(self, name, value):
-    #     if self.debug_info is not None:
-    #         event = self.debug_info.get(name)
-    #         if event is None:
-    #             self.error("Cache access response is not found: {0}".format(name))
-    #         else:
-    #             now = time.time()
-    #             event.update({
-    #                 'completed': now,
-    #                 'took': now - event['started'],
-    #                 'value': repr(value),
-    #                 })
-
     def request_started(self, request):
         self.debug('Requesting {} {}'.format(request.method, request.url), extra={_SKIP_EVENT: True})
         if self.debug_info is not None:
@@ -126,14 +104,16 @@ class PageLogger(logging.LoggerAdapter):
                 })
 
         level = logging.DEBUG
+        extra_data = {}
         if 400 <= resp.code < 500:
             level = logging.INFO
         elif resp.code >= 500:
             level = logging.ERROR
+            extra_data["req_body"] = resp.request.body
 
-        self.log(level, 'Complete {} {} {} in {}ms'.format(resp.code, resp.request.method, resp.request.url,
-                                                           int(resp.request_time * 1000.0)),
-                 extra={_SKIP_EVENT: True})
+        self.log(level, 'Complete %s %s %s in %sms', resp.code, resp.request.method, resp.request.url,
+                                                           int(resp.request_time * 1000.0),
+                 extra={_SKIP_EVENT: True, **extra_data})
 
     def add_metric(self, name, value):
         self.metrics[name] = value

--- a/tortik/page/__init__.py
+++ b/tortik/page/__init__.py
@@ -32,10 +32,20 @@ from tortik.util.async_group import AsyncGroup
 from tortik.util.parse import parse_xml, parse_json
 
 
-define('debug_password', default=None, type=str, help='Password for debug')
-define('debug', default=True, type=bool, help='Debug mode')
-define('tortik_max_clients', default=200, type=int, help='Max clients (requests) for http_client')
-define('tortik_timeout_multiplier', default=1.0, type=float, help='Timeout multiplier (affects all requests)')
+define("debug_password", default=None, type=str, help="Password for debug")
+define("debug", default=True, type=bool, help="Debug mode")
+define(
+    "tortik_max_clients",
+    default=200,
+    type=int,
+    help="Max clients (requests) for http_client",
+)
+define(
+    "tortik_timeout_multiplier",
+    default=1.0,
+    type=float,
+    help="Timeout multiplier (affects all requests)",
+)
 
 _DEBUG_ALL = "all"
 _DEBUG_ONLY_ERRORS = "only_errors"
@@ -45,12 +55,16 @@ stats = count()
 
 
 def _gen_requestid():
-    return hashlib.md5('{}{}{}'.format(os.getpid(), next(stats), random.random()).encode('utf-8')).hexdigest()
+    return hashlib.md5(
+        "{}{}{}".format(os.getpid(), next(stats), random.random()).encode("utf-8")
+    ).hexdigest()
 
 
-_decorates = decorate_all([
-    (tornado.web.asynchronous, 'asynchronous'),  # should be the last
-])
+_decorates = decorate_all(
+    [
+        (tornado.web.asynchronous, "asynchronous"),  # should be the last
+    ]
+)
 
 
 @six.add_metaclass(_decorates)
@@ -61,13 +75,16 @@ class RequestHandler(tornado.web.RequestHandler):
 
     Handler completion should be done with ``self.complete`` method
     instead of ``self.finish`` for applying postprocessors.
-     """
+    """
 
     def initialize(self, *args, **kwargs):
         debug_pass = options.debug_password
-        debug_agrs = self.get_arguments('debug')
-        debug_arg_set = (len(debug_agrs) > 0 and debug_pass is not None and
-                         (debug_pass == '' or debug_pass == debug_agrs[-1]))
+        debug_agrs = self.get_arguments("debug")
+        debug_arg_set = (
+            len(debug_agrs) > 0
+            and debug_pass is not None
+            and (debug_pass == "" or debug_pass == debug_agrs[-1])
+        )
 
         if debug_arg_set:
             self.debug_type = _DEBUG_ALL
@@ -76,29 +93,41 @@ class RequestHandler(tornado.web.RequestHandler):
         else:
             self.debug_type = _DEBUG_NONE
 
-        if self.debug_type != _DEBUG_NONE and not hasattr(RequestHandler, 'debug_loader'):
-            environment = Environment(autoescape=True,
-                                      loader=PackageLoader('tortik', 'templates'),
-                                      extensions=['jinja2.ext.autoescape'],
-                                      auto_reload=options.debug)
+        if self.debug_type != _DEBUG_NONE and not hasattr(
+            RequestHandler, "debug_loader"
+        ):
+            environment = Environment(
+                autoescape=True,
+                loader=PackageLoader("tortik", "templates"),
+                extensions=["jinja2.ext.autoescape"],
+                auto_reload=options.debug,
+            )
 
-            environment.filters['split'] = lambda x, y: x.split(y)
+            environment.filters["split"] = lambda x, y: x.split(y)
             RequestHandler.debug_loader = environment
 
         self.error_detected = False
 
-        self.request_id = self.request.headers.get('X-Request-Id', _gen_requestid())
+        self.request_id = self.request.headers.get("X-Request-Id", _gen_requestid())
 
-        self.log = PageLogger(self.request, self.request_id, (self.debug_type != _DEBUG_NONE),
-                              handler_name=(type(self).__module__ + '.' + type(self).__name__))
+        self.log = PageLogger(
+            self.request,
+            self.request_id,
+            (self.debug_type != _DEBUG_NONE),
+            handler_name=(type(self).__module__ + "." + type(self).__name__),
+        )
 
         self.responses = {}
         self.http_client = self.initialize_http_client()
 
-        self.preprocessors = copy(self.preprocessors) if hasattr(self, 'preprocessors') else []
-        self.postprocessors = copy(self.postprocessors) if hasattr(self, 'postprocessors') else []
+        self.preprocessors = (
+            copy(self.preprocessors) if hasattr(self, "preprocessors") else []
+        )
+        self.postprocessors = (
+            copy(self.postprocessors) if hasattr(self, "postprocessors") else []
+        )
 
-        self.log.debug('Using http client: %s' % repr(self.http_client))
+        self.log.debug("Using http client: %s" % repr(self.http_client))
 
         self._extra_data = {}
 
@@ -107,13 +136,16 @@ class RequestHandler(tornado.web.RequestHandler):
         if self.preprocessors:
             start_time = time.time()
             yield list(map(lambda x: tornado.gen.Task(x, self), self.preprocessors))
-            self.log.debug("Preprocessors completed in %.2fms", (time.time() - start_time)*1000.)
+            self.log.debug(
+                "Preprocessors completed in %.2fms", (time.time() - start_time) * 1000.0
+            )
 
     @staticmethod
     def get_global_http_client():
-        if not hasattr(RequestHandler, '_http_client'):
+        if not hasattr(RequestHandler, "_http_client"):
             RequestHandler._http_client = tornado.httpclient.AsyncHTTPClient(
-                max_clients=options.tortik_max_clients)
+                max_clients=options.tortik_max_clients
+            )
 
         return RequestHandler._http_client
 
@@ -134,10 +166,14 @@ class RequestHandler(tornado.web.RequestHandler):
 
     def write_error(self, status_code, **kwargs):
         if self.debug_type in [_DEBUG_ALL, _DEBUG_ONLY_ERRORS]:
-            if 'exc_info' in kwargs:
-                type, value, tb = kwargs['exc_info']
-                self.log.error("Uncaught exception %s\n%r", self._request_summary(),
-                               self.request, exc_info=(type, value, tb))
+            if "exc_info" in kwargs:
+                type, value, tb = kwargs["exc_info"]
+                self.log.error(
+                    "Uncaught exception %s\n%r",
+                    self._request_summary(),
+                    self.request,
+                    exc_info=(type, value, tb),
+                )
 
             if self._finished:
                 return
@@ -151,22 +187,31 @@ class RequestHandler(tornado.web.RequestHandler):
             super(RequestHandler, self).write_error(status_code, **kwargs)
 
     def finish_with_debug(self):
-        self.set_header('Content-Type', 'text/html; charset=utf-8')
+        self.set_header("Content-Type", "text/html; charset=utf-8")
         if self.debug_type == _DEBUG_ALL:
             self.set_status(200)
 
-        self.finish(RequestHandler.debug_loader.get_template('debug.html').render(
-            data=self.log.get_debug_info(),
-            output_data=self.get_data(),
-            size=sys.getsizeof,
-            get_params=lambda x: urlparse.parse_qs(x, keep_blank_values=True),
-            pretty_json=lambda x: json.dumps(x, sort_keys=True, indent=4, ensure_ascii=False),
-            pretty_xml=lambda x: to_unicode(tostring(x.getroot() if hasattr(x, 'getroot') else x,
-                                                     pretty_print=True, encoding='UTF-8')),
-            to_unicode=to_unicode,
-            dumper=dump,
-            format_exception=lambda x: "".join(traceback.format_exception(*x))
-        ))
+        self.finish(
+            RequestHandler.debug_loader.get_template("debug.html").render(
+                data=self.log.get_debug_info(),
+                output_data=self.get_data(),
+                size=sys.getsizeof,
+                get_params=lambda x: urlparse.parse_qs(x, keep_blank_values=True),
+                pretty_json=lambda x: json.dumps(
+                    x, sort_keys=True, indent=4, ensure_ascii=False
+                ),
+                pretty_xml=lambda x: to_unicode(
+                    tostring(
+                        x.getroot() if hasattr(x, "getroot") else x,
+                        pretty_print=True,
+                        encoding="UTF-8",
+                    )
+                ),
+                to_unicode=to_unicode,
+                dumper=dump,
+                format_exception=lambda x: "".join(traceback.format_exception(*x)),
+            )
+        )
 
     def complete(self, output_data=None):
         def finished_cb(handler, data):
@@ -184,15 +229,17 @@ class RequestHandler(tornado.web.RequestHandler):
                 if index == last:
                     return finished_cb
                 else:
+
                     def _cb(handler, data):
                         self.postprocessors[index + 1](handler, data, add_cb(index + 1))
+
                     return _cb
 
             self.postprocessors[0](self, output_data, add_cb(0))
         else:
             finished_cb(self, output_data)
 
-    def fetch_requests(self, requests, callback=None, stage='page'):
+    def fetch_requests(self, requests, callback=None, stage="page"):
         self.log.stage_started(stage)
         requests = make_list(requests)
 
@@ -204,19 +251,22 @@ class RequestHandler(tornado.web.RequestHandler):
         ag = AsyncGroup(_finish_cb, self.log.debug, name=stage)
 
         def _on_fetch(response, name):
-            content_type = response.headers.get('Content-Type', '').split(';')[0]
+            content_type = response.headers.get("Content-Type", "").split(";")[0]
             response.data = None
             self.log.debug(
                 'Got response for "%s" (code = %s, content_type = %s): %.200s',
-                name, response.code, content_type, response.body.decode('utf-8', errors='replace'),
+                name,
+                response.code,
+                content_type,
+                response.body.decode("utf-8", errors="replace"),
             )
             try:
-                if 'xml' in content_type:
+                if "xml" in content_type:
                     response.data = parse_xml(response)
-                elif content_type == 'application/json':
+                elif content_type == "application/json":
                     response.data = parse_json(response)
             except:
-                self.log.warning('Could not parse response with Content-Type header')
+                self.log.warning("Could not parse response with Content-Type header")
 
             if response.data is not None:
                 self.add(name, response.data)
@@ -227,13 +277,30 @@ class RequestHandler(tornado.web.RequestHandler):
         for req in requests:
             if isinstance(req, (tuple, list)):
                 assert len(req) in (2, 3)
-                req = self.make_request(name=req[0], method='GET', full_url=req[1],
-                                        data=req[2] if len(req) == 3 else '')
+                req = self.make_request(
+                    name=req[0],
+                    method="GET",
+                    full_url=req[1],
+                    data=req[2] if len(req) == 3 else "",
+                )
             self.log.request_started(req)
             self.http_client.fetch(req, ag.add(partial(_on_fetch, name=req.name)))
 
-    def make_request(self, name, method='GET', full_url=None, url_prefix=None, path='', data='', headers=None,
-                     connect_timeout=1, request_timeout=2, follow_redirects=True, safe='/', **kwargs):
+    def make_request(
+        self,
+        name,
+        method="GET",
+        full_url=None,
+        url_prefix=None,
+        path="",
+        data="",
+        headers=None,
+        connect_timeout=1,
+        request_timeout=2,
+        follow_redirects=True,
+        safe="/",
+        **kwargs
+    ):
         """
         Class for easier constructing ``tornado.httpclient.HTTPRequest`` object.
 
@@ -259,12 +326,14 @@ class RequestHandler(tornado.web.RequestHandler):
         """
 
         if (full_url is None) == (url_prefix is None):
-            raise TypeError('make_request required path/url_prefix arguments pair or full_url argument')
-        if full_url is not None and path != '':
+            raise TypeError(
+                "make_request required path/url_prefix arguments pair or full_url argument"
+            )
+        if full_url is not None and path != "":
             raise TypeError("Can't combine full_url and path arguments")
 
-        scheme = 'http'
-        query = ''
+        scheme = "http"
+        query = ""
         body = None
 
         if full_url is not None:
@@ -274,28 +343,34 @@ class RequestHandler(tornado.web.RequestHandler):
             path = parsed_full_url.path
             query = parsed_full_url.query
 
-        if method in ['GET', 'HEAD', 'DELETE']:
+        if method in ["GET", "HEAD", "DELETE"]:
             parsed_query = urlparse.parse_qs(query)
-            parsed_query.update(data if isinstance(data, dict) else urlparse.parse_qs(data))
+            parsed_query.update(
+                data if isinstance(data, dict) else urlparse.parse_qs(data)
+            )
             query = make_qs(parsed_query, safe=safe)
         else:
             body = make_qs(data, safe=safe) if isinstance(data, dict) else data
 
         headers = {} if headers is None else headers
 
-        headers.update({
-            'X-Forwarded-For': real_ip(self.request),
-            'X-Request-Id': self.request_id,
-            'Content-Type': headers.get('Content-Type', 'application/x-www-form-urlencoded')
-        })
+        headers.update(
+            {
+                "X-Forwarded-For": real_ip(self.request),
+                "X-Request-Id": self.request_id,
+                "Content-Type": headers.get(
+                    "Content-Type", "application/x-www-form-urlencoded"
+                ),
+            }
+        )
 
         req = tornado.httpclient.HTTPRequest(
-            url=urlparse.urlunsplit((scheme, url_prefix, path, query, '')),
+            url=urlparse.urlunsplit((scheme, url_prefix, path, query, "")),
             method=method,
             headers=headers,
             body=body,
-            connect_timeout=connect_timeout*options.tortik_timeout_multiplier,
-            request_timeout=request_timeout*options.tortik_timeout_multiplier,
+            connect_timeout=connect_timeout * options.tortik_timeout_multiplier,
+            request_timeout=request_timeout * options.tortik_timeout_multiplier,
             follow_redirects=follow_redirects,
             **kwargs
         )

--- a/tortik/util/__init__.py
+++ b/tortik/util/__init__.py
@@ -18,11 +18,14 @@ def decorate_all(decorator_list):
     def is_method_need_to_decorate(func_name, func_obj, check_param):
         """check if an object should be decorated"""
         methods = ["get", "head", "post", "put", "delete", "patch"]
-        return (func_name in methods and
-                isinstance(func_obj, FunctionType) and
-                getattr(func_obj, check_param, True))
+        return (
+            func_name in methods
+            and isinstance(func_obj, FunctionType)
+            and getattr(func_obj, check_param, True)
+        )
 
     """decorate all instance methods (unless excluded) with the same decorator"""
+
     class DecorateAll(type):
         def __new__(cls, name, bases, dct):
             for func_name, func_obj in dct.items():
@@ -38,6 +41,7 @@ def decorate_all(decorator_list):
                 if is_method_need_to_decorate(func_name, func_obj, check_param):
                     func_obj = decorator(func_obj)
             super(DecorateAll, self).__setattr__(func_name, func_obj)
+
     return DecorateAll
 
 
@@ -50,8 +54,12 @@ def make_list(val):
 
 def real_ip(request):
     # split is for X-Forwarded-For header that can consist of many IPs: X-Forwarded-For: client, proxy1, proxy2
-    return (request.headers.get('X-Forwarded-For', None) or request.headers.get('X-Real-Ip', None) or
-            request.remote_ip or '127.0.0.1').split(',')[0]
+    return (
+        request.headers.get("X-Forwarded-For", None)
+        or request.headers.get("X-Real-Ip", None)
+        or request.remote_ip
+        or "127.0.0.1"
+    ).split(",")[0]
 
 
 HTTPError = tornado.web.HTTPError
@@ -59,11 +67,11 @@ ITERABLE = (set, frozenset, list, tuple)
 
 
 def update_url(url, update_args=None, remove_args=None):
-    scheme, sep, url_new = url.partition('://')
+    scheme, sep, url_new = url.partition("://")
     if len(scheme) == len(url):
-        scheme = ''
+        scheme = ""
     else:
-        url = '//' + url_new
+        url = "//" + url_new
 
     url_split = urlparse.urlsplit(url)
     query_dict = urlparse.parse_qs(url_split.query, keep_blank_values=True)
@@ -74,20 +82,24 @@ def update_url(url, update_args=None, remove_args=None):
 
     # remove args
     if remove_args:
-        query_dict = dict([(k, query_dict.get(k)) for k in query_dict if k not in remove_args])
+        query_dict = dict(
+            [(k, query_dict.get(k)) for k in query_dict if k not in remove_args]
+        )
 
     query = make_qs(query_dict)
-    return urlparse.urlunsplit((scheme, url_split.netloc, url_split.path, query, url_split.fragment))
+    return urlparse.urlunsplit(
+        (scheme, url_split.netloc, url_split.path, query, url_split.fragment)
+    )
 
 
 def _encode(s):
     if isinstance(s, unicode_type):
-        return s.encode('utf-8')
+        return s.encode("utf-8")
     else:
         return s
 
 
-def make_qs(query_args, safe='/'):
+def make_qs(query_args, safe="/"):
     kv_pairs = []
     for key, val in query_args.items():
         if val is not None:

--- a/tortik/util/async_group.py
+++ b/tortik/util/async_group.py
@@ -22,9 +22,9 @@ class AsyncGroup(object):
         self.finish_time = None
 
         if self.name is not None:
-            self.log_name = '{0} group'.format(self.name)
+            self.log_name = "{0} group".format(self.name)
         else:
-            self.log_name = 'group'
+            self.log_name = "group"
 
     def _log(self, msg, *args, **kw):
         self.log_fun(self.log_name + ": " + msg, *args, **kw)
@@ -32,7 +32,7 @@ class AsyncGroup(object):
     def finish(self):
         if not self.finished:
             self.finish_time = time.time()
-            self._log('done in %.2fms', (self.finish_time - self.start_time)*1000.)
+            self._log("done in %.2fms", (self.finish_time - self.start_time) * 1000.0)
             self.finished = True
 
             try:
@@ -46,12 +46,12 @@ class AsyncGroup(object):
             self.finish()
 
     def _inc(self):
-        assert(not self.finished)
+        assert not self.finished
         self.counter += 1
 
     def _dec(self):
         self.counter -= 1
-        self._log('%s requests pending', self.counter)
+        self._log("%s requests pending", self.counter)
 
     def add(self, intermediate_cb):
         self._inc()
@@ -69,7 +69,7 @@ class AsyncGroup(object):
                 else:
                     self.try_finish()
             else:
-                self._log('Ignoring response because of already finished group')
+                self._log("Ignoring response because of already finished group")
 
         return wrapper
 

--- a/tortik/util/dumper.py
+++ b/tortik/util/dumper.py
@@ -8,36 +8,38 @@ from . import ITERABLE
 def dump(obj):
     refs = set()
 
-    def primitive(value, ptype='string'):
+    def primitive(value, ptype="string"):
         return dict(type=ptype, value=value)
 
     def _make_dump(item):
         if isinstance(item, ITERABLE):
             if len(item) == 0:
-                return dict(type='array', value=[])
+                return dict(type="array", value=[])
             if id(item) in refs:
-                return primitive('<circular reference>')
+                return primitive("<circular reference>")
 
             refs.add(id(item))
-            return dict(type='array', value=list(map(lambda x: _make_dump(x), item)))
+            return dict(type="array", value=list(map(lambda x: _make_dump(x), item)))
         elif isinstance(item, dict):
             if not item:
-                return dict(type='dict', value=dict())
+                return dict(type="dict", value=dict())
             if id(item) in refs:
-                return primitive('<circular reference>')
+                return primitive("<circular reference>")
             refs.add(id(item))
 
-            return dict(type='dict', value=dict((x, _make_dump(y)) for x, y in item.items()))
+            return dict(
+                type="dict", value=dict((x, _make_dump(y)) for x, y in item.items())
+            )
         elif isinstance(item, bool):
-            return primitive('true' if item else 'false', 'bool')
+            return primitive("true" if item else "false", "bool")
         elif isinstance(item, basestring_type):
             return primitive(item)
         elif isinstance(item, (int, float)):
-            return primitive(item, 'number')
+            return primitive(item, "number")
         elif item is None:
-            return primitive('null', 'null')
+            return primitive("null", "null")
         else:
-            return primitive(repr(item), 'string')
+            return primitive(repr(item), "string")
 
     return _make_dump(obj)
 
@@ -48,26 +50,33 @@ def request_to_curl_string(request):
 
     try:
         if request.body:
-            request.body.decode('ascii')
+            request.body.decode("ascii")
         is_binary_data = False
     except UnicodeError:
         is_binary_data = True
 
     curl_headers = HTTPHeaders(request.headers)
-    if request.body and 'Content-Length' not in curl_headers:
-        curl_headers['Content-Length'] = len(request.body)
+    if request.body and "Content-Length" not in curl_headers:
+        curl_headers["Content-Length"] = len(request.body)
 
     if is_binary_data:
         curl_echo_data = "echo -e {} |".format(repr(request.body))
-        curl_data_string = '--data-binary @-'
+        curl_data_string = "--data-binary @-"
     else:
-        curl_echo_data = ''
-        curl_data_string = "--data '{}'".format(_escape_apos(str(request.body))) if request.body else ''
+        curl_echo_data = ""
+        curl_data_string = (
+            "--data '{}'".format(_escape_apos(str(request.body)))
+            if request.body
+            else ""
+        )
 
     return "{echo} curl -X {method} '{url}' {headers} {data}".format(
         echo=curl_echo_data,
         method=request.method,
         url=request.url,
-        headers=' '.join("-H '{}: {}'".format(k, _escape_apos(str(v))) for k, v in curl_headers.items()),
-        data=curl_data_string
+        headers=" ".join(
+            "-H '{}: {}'".format(k, _escape_apos(str(v)))
+            for k, v in curl_headers.items()
+        ),
+        data=curl_data_string,
     ).strip()

--- a/tortik/util/parse.py
+++ b/tortik/util/parse.py
@@ -12,18 +12,20 @@ except ImportError:
 
 def parse_xml(response):
     if response.code == 599 or response.buffer is None:
-        raise HTTPError(httplib.SERVICE_UNAVAILABLE, 'Response timeout or no body buffer')
+        raise HTTPError(
+            httplib.SERVICE_UNAVAILABLE, "Response timeout or no body buffer"
+        )
     try:
         return parse(response.buffer)
     except ParseError:
-        raise HTTPError(httplib.SERVICE_UNAVAILABLE, 'Unable to parse xml')
+        raise HTTPError(httplib.SERVICE_UNAVAILABLE, "Unable to parse xml")
 
 
 def parse_json(response):
     if response.code == 599 or response.body is None:
-        raise HTTPError(httplib.SERVICE_UNAVAILABLE, 'Response timeout or no body')
+        raise HTTPError(httplib.SERVICE_UNAVAILABLE, "Response timeout or no body")
     try:
         result = json_decode(response.body)
     except ValueError:
-        raise HTTPError(httplib.SERVICE_UNAVAILABLE, 'Unable to parse json')
+        raise HTTPError(httplib.SERVICE_UNAVAILABLE, "Unable to parse json")
     return result

--- a/tortik/util/url.py
+++ b/tortik/util/url.py
@@ -3,7 +3,7 @@ import sys
 from urllib import quote_plus, _is_unicode
 
 
-def urlencode(query, doseq=0, safe='/'):
+def urlencode(query, doseq=0, safe="/"):
     """Patched py2 version of urlencode - added `safe` parameter (py3 version
     supports this).
 
@@ -19,7 +19,7 @@ def urlencode(query, doseq=0, safe='/'):
     input.
     """
 
-    if hasattr(query,"items"):
+    if hasattr(query, "items"):
         # mapping objects
         query = query.items()
     else:
@@ -35,7 +35,7 @@ def urlencode(query, doseq=0, safe='/'):
             # allowed empty dicts that type of behavior probably should be
             # preserved for consistency
         except TypeError:
-            ty,va,tb = sys.exc_info()
+            ty, va, tb = sys.exc_info()
             raise TypeError, "not a valid non-string sequence or mapping object", tb
 
     l = []
@@ -44,19 +44,19 @@ def urlencode(query, doseq=0, safe='/'):
         for k, v in query:
             k = quote_plus(str(k), safe=safe)
             v = quote_plus(str(v), safe=safe)
-            l.append(k + '=' + v)
+            l.append(k + "=" + v)
     else:
         for k, v in query:
             k = quote_plus(str(k), safe=safe)
             if isinstance(v, str):
                 v = quote_plus(v, safe=safe)
-                l.append(k + '=' + v)
+                l.append(k + "=" + v)
             elif _is_unicode(v):
                 # is there a reasonable way to convert to ASCII?
                 # encode generates a string, but "replace" or "ignore"
                 # lose information and "strict" can raise UnicodeError
-                v = quote_plus(v.encode("ASCII","replace"), safe=safe)
-                l.append(k + '=' + v)
+                v = quote_plus(v.encode("ASCII", "replace"), safe=safe)
+                l.append(k + "=" + v)
             else:
                 try:
                     # is this a sufficient test for sequence-ness?
@@ -64,9 +64,9 @@ def urlencode(query, doseq=0, safe='/'):
                 except TypeError:
                     # not a sequence
                     v = quote_plus(str(v), safe=safe)
-                    l.append(k + '=' + v)
+                    l.append(k + "=" + v)
                 else:
                     # loop over the sequence
                     for elt in v:
-                        l.append(k + '=' + quote_plus(str(elt), safe=safe))
-    return '&'.join(l)
+                        l.append(k + "=" + quote_plus(str(elt), safe=safe))
+    return "&".join(l)

--- a/tortik/util/xml_etree.py
+++ b/tortik/util/xml_etree.py
@@ -6,7 +6,7 @@ native_etree = False
 try:
     from lxml import etree
 except ImportError:
-    tortik_log.info('lxml not installed. Using native etree implementation')
+    tortik_log.info("lxml not installed. Using native etree implementation")
     native_etree = True
     import xml.etree.ElementTree as etree
 
@@ -19,7 +19,7 @@ def parse(source, parser=None):
 
 
 def tostring(element, **kwargs):
-    native_args = ['encoding', 'method']
+    native_args = ["encoding", "method"]
     if native_etree is True:
         pass_args = dict()
         for a in native_args:

--- a/tortik/version.py
+++ b/tortik/version.py
@@ -13,4 +13,4 @@ def __parse_version_from_changelog():
     except (IOError, AttributeError):
         return None
 
-version = __parse_version_from_changelog() or '0.2.10'
+version = __parse_version_from_changelog() or '0.2.11'

--- a/tortik/version.py
+++ b/tortik/version.py
@@ -6,11 +6,16 @@ import re
 
 def __parse_version_from_changelog():
     try:
-        deb_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'debian', 'changelog')
-        with open(deb_path, 'r') as changelog:
-            regmatch = re.match(r'python-tortik \((.*)\).*', changelog.readline())
+        deb_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "debian",
+            "changelog",
+        )
+        with open(deb_path, "r") as changelog:
+            regmatch = re.match(r"python-tortik \((.*)\).*", changelog.readline())
             return regmatch.groups()[0]
     except (IOError, AttributeError):
         return None
 
-version = __parse_version_from_changelog() or '0.2.11'
+
+version = __parse_version_from_changelog() or "0.2.11"

--- a/tortik_tests/debug_test.py
+++ b/tortik_tests/debug_test.py
@@ -13,71 +13,76 @@ import tortik.logger
 
 def preprocessor(handler, callback):
     def handle_request():
-        handler.log.info('Log from preprocessor')
+        handler.log.info("Log from preprocessor")
         callback()
 
     handler.fetch_requests(
         [
             handler.make_request(
-                name='mock_json',
-                method='GET',
-                full_url=handler.request.protocol + "://" + handler.request.host + '/mock/json',
-                request_timeout=0.2
+                name="mock_json",
+                method="GET",
+                full_url=handler.request.protocol
+                + "://"
+                + handler.request.host
+                + "/mock/json",
+                request_timeout=0.2,
             ),
             handler.make_request(
-                name='mock_xml',
-                method='GET',
-                full_url=handler.request.protocol + "://" + handler.request.host + '/mock/xml',
-                request_timeout=0.2
-            )
+                name="mock_xml",
+                method="GET",
+                full_url=handler.request.protocol
+                + "://"
+                + handler.request.host
+                + "/mock/xml",
+                request_timeout=0.2,
+            ),
         ],
-        callback=handle_request
+        callback=handle_request,
     )
 
 
 def postprocessor(handler, data, callback):
-    handler.log.info('Log from postprocessor')
+    handler.log.info("Log from postprocessor")
     callback(handler, data)
 
 
 class MainHandler(RequestHandler):
-    preprocessors = [
-        preprocessor
-    ]
-    postprocessors = [
-        postprocessor
-    ]
+    preprocessors = [preprocessor]
+    postprocessors = [postprocessor]
 
     def get(self):
-        self.complete('Hello, world!')
+        self.complete("Hello, world!")
 
 
 class ExceptionHandler(MainHandler):
     def get(self):
         test = 1 / 0
-        self.complete('Hello, world!')
+        self.complete("Hello, world!")
 
 
 class XmlDebugHandler(MainHandler):
     def get(self):
         def handle_request():
-            self.complete('Hello, world!')
+            self.complete("Hello, world!")
 
         self.fetch_requests(
             self.make_request(
-                name='xml',
-                method='GET',
-                full_url=self.request.protocol + "://" + self.request.host + '/mock/xml',
-                request_timeout=0.2
+                name="xml",
+                method="GET",
+                full_url=self.request.protocol
+                + "://"
+                + self.request.host
+                + "/mock/xml",
+                request_timeout=0.2,
             ),
-            callback=handle_request
+            callback=handle_request,
         )
 
 
 class MockJsonHandler(tornado.web.RequestHandler):
     @staticmethod
     def mock_data():
-        fd = open(os.path.join(os.path.dirname(__file__), 'data', 'simple.json'), 'r')
+        fd = open(os.path.join(os.path.dirname(__file__), "data", "simple.json"), "r")
         data = json_decode(fd.read())
         fd.close()
         return data
@@ -89,13 +94,13 @@ class MockJsonHandler(tornado.web.RequestHandler):
 class MockXmlHandler(tornado.web.RequestHandler):
     @staticmethod
     def mock_data():
-        fd = open(os.path.join(os.path.dirname(__file__), 'data', 'simple.xml'), 'r')
+        fd = open(os.path.join(os.path.dirname(__file__), "data", "simple.xml"), "r")
         data = fd.read()
         fd.close()
         return data
 
     def get(self):
-        self.set_header('Content-Type', 'application/xml')
+        self.set_header("Content-Type", "application/xml")
         self.finish(self.mock_data())
 
 
@@ -121,7 +126,7 @@ class DebugHTTPTestCase(AsyncHTTPTestCase):
         self._old_debug = options.debug
         self._old_debug_password = options.debug_password
         options.debug = True
-        options.debug_password = ''
+        options.debug_password = ""
 
         super(DebugHTTPTestCase, self).setUp()
 
@@ -137,28 +142,28 @@ class DebugHTTPTestCase(AsyncHTTPTestCase):
         return tornado.ioloop.IOLoop.instance()
 
     def test_main(self):
-        self.http_client.fetch(self.get_url('/?debug'), self.stop)
+        self.http_client.fetch(self.get_url("/?debug"), self.stop)
         response = self.wait()
         self.assertEqual(200, response.code)
-        self.assertIn(b'Log from preprocessor', response.body)
-        self.assertIn(b'Log from postprocessor', response.body)
-        self.assertIn(b'/mock/json', response.body)
+        self.assertIn(b"Log from preprocessor", response.body)
+        self.assertIn(b"Log from postprocessor", response.body)
+        self.assertIn(b"/mock/json", response.body)
 
     def test_exception(self):
-        self.http_client.fetch(self.get_url('/exception'), self.stop)
+        self.http_client.fetch(self.get_url("/exception"), self.stop)
         response = self.wait()
         self.assertEqual(500, response.code)
-        self.assertIn(b'Log from preprocessor', response.body)
-        self.assertNotIn(b'Log from postprocessor', response.body)
-        self.assertIn(b'/mock/json', response.body)
-        self.assertIn(b'ZeroDivisionError', response.body)
+        self.assertIn(b"Log from preprocessor", response.body)
+        self.assertNotIn(b"Log from postprocessor", response.body)
+        self.assertIn(b"/mock/json", response.body)
+        self.assertIn(b"ZeroDivisionError", response.body)
 
     def test_debug_exception(self):
-        self.http_client.fetch(self.get_url('/exception?debug'), self.stop)
+        self.http_client.fetch(self.get_url("/exception?debug"), self.stop)
         response = self.wait()
         self.assertEqual(200, response.code)
-        self.assertIn(b'code=500', response.body)
-        self.assertIn(b'ZeroDivisionError', response.body)
+        self.assertIn(b"code=500", response.body)
+        self.assertIn(b"ZeroDivisionError", response.body)
 
 
 class DebugPasswordHTTPTestCase(AsyncHTTPTestCase):
@@ -166,7 +171,7 @@ class DebugPasswordHTTPTestCase(AsyncHTTPTestCase):
         self._old_debug = options.debug
         self._old_debug_password = options.debug_password
         options.debug = False
-        options.debug_password = '123'
+        options.debug_password = "123"
 
         super(DebugPasswordHTTPTestCase, self).setUp()
 
@@ -182,37 +187,37 @@ class DebugPasswordHTTPTestCase(AsyncHTTPTestCase):
         return tornado.ioloop.IOLoop.instance()
 
     def test_debug_false(self):
-        self.http_client.fetch(self.get_url('/?debug'), self.stop)
+        self.http_client.fetch(self.get_url("/?debug"), self.stop)
         response = self.wait()
         self.assertEqual(200, response.code)
-        self.assertNotIn(b'Log from preprocessor', response.body)
-        self.assertNotIn(b'Log from postprocessor', response.body)
-        self.assertNotIn(b'/mock/json', response.body)
-        self.assertIn(b'Hello, world!', response.body)
+        self.assertNotIn(b"Log from preprocessor", response.body)
+        self.assertNotIn(b"Log from postprocessor", response.body)
+        self.assertNotIn(b"/mock/json", response.body)
+        self.assertIn(b"Hello, world!", response.body)
 
     def test_debug_true(self):
-        self.http_client.fetch(self.get_url('/?debug=123'), self.stop)
+        self.http_client.fetch(self.get_url("/?debug=123"), self.stop)
         response = self.wait()
         self.assertEqual(200, response.code)
-        self.assertIn(b'Log from preprocessor', response.body)
-        self.assertIn(b'Log from postprocessor', response.body)
-        self.assertIn(b'/mock/json', response.body)
+        self.assertIn(b"Log from preprocessor", response.body)
+        self.assertIn(b"Log from postprocessor", response.body)
+        self.assertIn(b"/mock/json", response.body)
 
     def test_exception(self):
-        self.http_client.fetch(self.get_url('/exception'), self.stop)
+        self.http_client.fetch(self.get_url("/exception"), self.stop)
         response = self.wait()
         self.assertEqual(500, response.code)
-        self.assertNotIn(b'Log from preprocessor', response.body)
-        self.assertNotIn(b'Log from postprocessor', response.body)
-        self.assertNotIn(b'/mock/json', response.body)
-        self.assertNotIn(b'Hello, world!', response.body)
+        self.assertNotIn(b"Log from preprocessor", response.body)
+        self.assertNotIn(b"Log from postprocessor", response.body)
+        self.assertNotIn(b"/mock/json", response.body)
+        self.assertNotIn(b"Hello, world!", response.body)
 
     def test_debug_exception(self):
-        self.http_client.fetch(self.get_url('/exception?debug=123'), self.stop)
+        self.http_client.fetch(self.get_url("/exception?debug=123"), self.stop)
         response = self.wait()
         self.assertEqual(200, response.code)
-        self.assertIn(b'code=500', response.body)
-        self.assertIn(b'ZeroDivisionError', response.body)
+        self.assertIn(b"code=500", response.body)
+        self.assertIn(b"ZeroDivisionError", response.body)
 
 
 class DebugTurnedOffHTTPTestCase(AsyncHTTPTestCase):
@@ -232,19 +237,19 @@ class DebugTurnedOffHTTPTestCase(AsyncHTTPTestCase):
         return tornado.ioloop.IOLoop.instance()
 
     def test_debug(self):
-        self.http_client.fetch(self.get_url('/?debug'), self.stop)
+        self.http_client.fetch(self.get_url("/?debug"), self.stop)
         response = self.wait()
         self.assertEqual(200, response.code)
-        self.assertNotIn(b'Log from preprocessor', response.body)
-        self.assertNotIn(b'Log from postprocessor', response.body)
-        self.assertNotIn(b'/mock/json', response.body)
-        self.assertIn(b'Hello, world!', response.body)
+        self.assertNotIn(b"Log from preprocessor", response.body)
+        self.assertNotIn(b"Log from postprocessor", response.body)
+        self.assertNotIn(b"/mock/json", response.body)
+        self.assertIn(b"Hello, world!", response.body)
 
     def test_debug_exception(self):
-        self.http_client.fetch(self.get_url('/exception'), self.stop)
+        self.http_client.fetch(self.get_url("/exception"), self.stop)
         response = self.wait()
         self.assertEqual(500, response.code)
-        self.assertNotIn(b'Log from preprocessor', response.body)
-        self.assertNotIn(b'Log from postprocessor', response.body)
-        self.assertNotIn(b'/mock/json', response.body)
-        self.assertNotIn(b'Hello, world!', response.body)
+        self.assertNotIn(b"Log from preprocessor", response.body)
+        self.assertNotIn(b"Log from postprocessor", response.body)
+        self.assertNotIn(b"/mock/json", response.body)
+        self.assertNotIn(b"Hello, world!", response.body)

--- a/tortik_tests/dumper_test.py
+++ b/tortik_tests/dumper_test.py
@@ -7,10 +7,13 @@ from tortik.util.dumper import dump
 
 class DumperTestCase(unittest.TestCase):
     def test_circular_reference(self):
-        a = {'a': 123}
-        a['b'] = a
-        expected = {'type': 'dict', 'value': {
-            'a': {'type': 'number', 'value': 123},
-            'b': {'type': 'string', 'value': '<circular reference>'}
-        }}
+        a = {"a": 123}
+        a["b"] = a
+        expected = {
+            "type": "dict",
+            "value": {
+                "a": {"type": "number", "value": 123},
+                "b": {"type": "string", "value": "<circular reference>"},
+            },
+        }
         self.assertEqual(expected, dump(a))

--- a/tortik_tests/exceptions_test.py
+++ b/tortik_tests/exceptions_test.py
@@ -8,7 +8,7 @@ from tortik.page import RequestHandler
 
 
 def preprocessor(handler, callback):
-    callback(1/0)
+    callback(1 / 0)
 
 
 def check_postprocessor(handler, data, callback):
@@ -17,28 +17,22 @@ def check_postprocessor(handler, data, callback):
 
 
 def postprocessor(handler, data, callback):
-    callback(handler, 1/0)
+    callback(handler, 1 / 0)
 
 
 class MainHandler(RequestHandler):
-    preprocessors = [
-        preprocessor
-    ]
-    postprocessors = [
-        check_postprocessor
-    ]
+    preprocessors = [preprocessor]
+    postprocessors = [check_postprocessor]
 
     def get(self):
-        self.complete({'status': 'ok'})
+        self.complete({"status": "ok"})
 
 
 class SecondHandler(RequestHandler):
-    postprocessors = [
-        postprocessor
-    ]
+    postprocessors = [postprocessor]
 
     def get(self):
-        self.complete({'status': 'ok'})
+        self.complete({"status": "ok"})
 
 
 class Application(tornado.web.Application):
@@ -62,11 +56,11 @@ class ExceptionsHTTPTestCase(AsyncHTTPTestCase):
         return tornado.ioloop.IOLoop.instance()
 
     def test_main(self):
-        self.http_client.fetch(self.get_url('/'), self.stop)
+        self.http_client.fetch(self.get_url("/"), self.stop)
         response = self.wait()
         self.assertEqual(500, response.code)
 
     def test_second(self):
-        self.http_client.fetch(self.get_url('/second'), self.stop)
+        self.http_client.fetch(self.get_url("/second"), self.stop)
         response = self.wait()
         self.assertEqual(500, response.code)

--- a/tortik_tests/import_test.py
+++ b/tortik_tests/import_test.py
@@ -8,9 +8,8 @@ from os import path
 
 
 class ImportAllPythonCodeTestCase(unittest.TestCase):
-
     def setUp(self):
-        self.pkg_dir = path.abspath(path.join(path.dirname(__file__), '..', 'tortik'))
+        self.pkg_dir = path.abspath(path.join(path.dirname(__file__), "..", "tortik"))
         self.pkg_name = path.basename(self.pkg_dir)
 
     def test_import_all(self):
@@ -25,25 +24,27 @@ class ImportAllPythonCodeTestCase(unittest.TestCase):
         try:
             importlib.import_module(module)
         except ImportError as e:
-            self.fail('Unable to import "{module}" module ({e!s}). \n\nSys paths:\n{paths}'.format(
-                module=module, e=e, paths='\n'.join(sys.path)
-            ))
+            self.fail(
+                'Unable to import "{module}" module ({e!s}). \n\nSys paths:\n{paths}'.format(
+                    module=module, e=e, paths="\n".join(sys.path)
+                )
+            )
 
     # ----------------------------------------------------
     def i_package_walk(self):
-        base_path = self.pkg_dir + '/'
+        base_path = self.pkg_dir + "/"
         base_path_len = len(base_path)
-        base_name = self.pkg_name + '.'
+        base_name = self.pkg_name + "."
         for root, dirs, files in os.walk(self.pkg_dir):
             for basename in files:
-                if basename.endswith('.py'):
+                if basename.endswith(".py"):
                     full_path = os.path.join(root, basename)
                     if full_path.startswith(base_path):
                         rel_path = full_path[base_path_len:]
-                        module = rel_path.replace('/', '.')[:-3]
-                        if module == '__init__':
+                        module = rel_path.replace("/", ".")[:-3]
+                        if module == "__init__":
                             module = self.pkg_name
-                        elif module.endswith('.__init__'):
+                        elif module.endswith(".__init__"):
                             module = base_name + module[:-9]
                         else:
                             module = base_name + module

--- a/tortik_tests/make_request_test.py
+++ b/tortik_tests/make_request_test.py
@@ -4,8 +4,8 @@ from unittest import TestCase
 
 from tortik.page import RequestHandler
 
-fake_real_ip = '127.5.5.5'
-fake_request_id = 'abcdef1234567890'
+fake_real_ip = "127.5.5.5"
+fake_request_id = "abcdef1234567890"
 
 
 class FakeRequest(object):
@@ -14,124 +14,131 @@ class FakeRequest(object):
 
 # py2 to py3
 _base_make_request = RequestHandler.make_request
-_make_request = _base_make_request.im_func if hasattr(_base_make_request, 'im_func') else _base_make_request
+_make_request = (
+    _base_make_request.im_func
+    if hasattr(_base_make_request, "im_func")
+    else _base_make_request
+)
 
 
 class FakeHandler(object):
     def __init__(self):
         self.request = FakeRequest()
         self.request_id = fake_request_id
-        self.request.headers = {
-            "X-Real-Ip": fake_real_ip
-        }
+        self.request.headers = {"X-Real-Ip": fake_real_ip}
 
     make_request = _make_request
 
 
 class MakeRequestTestCase(TestCase):
-
     def setUp(self):
         self.fake_handler = FakeHandler()
         self.fake_real_ip = fake_real_ip
 
     def test_full_url(self):
-        full_url = 'http://example.com/path_to'
-        request = self.fake_handler.make_request(name='abc', method='GET', full_url=full_url)
+        full_url = "http://example.com/path_to"
+        request = self.fake_handler.make_request(
+            name="abc", method="GET", full_url=full_url
+        )
 
         self.assertEqual(request.url, full_url)
 
     def test_full_url_add_query(self):
-        full_url = 'http://example.com/path_to'
-        request = self.fake_handler.make_request(name='abc', method='GET', full_url=full_url,
-                                                 data={'foo': 1})
+        full_url = "http://example.com/path_to"
+        request = self.fake_handler.make_request(
+            name="abc", method="GET", full_url=full_url, data={"foo": 1}
+        )
 
-        self.assertEqual(request.url, full_url+'?foo=1')
+        self.assertEqual(request.url, full_url + "?foo=1")
 
     def test_full_url_update_query(self):
-        full_url = 'http://example.com/path_to?bar=2'
-        request = self.fake_handler.make_request(name='abc', method='GET', full_url=full_url,
-                                                 data={'foo': 1})
+        full_url = "http://example.com/path_to?bar=2"
+        request = self.fake_handler.make_request(
+            name="abc", method="GET", full_url=full_url, data={"foo": 1}
+        )
         self.assertEqual(
-            sorted('bar=2&foo=1'.split('&')),
-            sorted(request.url.split('?')[1].split('&'))
+            sorted("bar=2&foo=1".split("&")),
+            sorted(request.url.split("?")[1].split("&")),
         )
 
     def test_full_url_update_same_query(self):
-        full_url = 'http://example.com/path_to?bar=2&bar=3'
-        request = self.fake_handler.make_request(name='abc', method='GET', full_url=full_url,
-                                                 data={'bar': [4, 5]})
+        full_url = "http://example.com/path_to?bar=2&bar=3"
+        request = self.fake_handler.make_request(
+            name="abc", method="GET", full_url=full_url, data={"bar": [4, 5]}
+        )
         self.assertEqual(
-            sorted('bar=4&bar=5'.split('&')),
-            sorted(request.url.split('?')[1].split('&'))
+            sorted("bar=4&bar=5".split("&")),
+            sorted(request.url.split("?")[1].split("&")),
         )
 
     def test_full_url_query(self):
-        full_url = 'http://example.com/path_to?foo=1'
-        request = self.fake_handler.make_request(name='abc', method='GET', full_url=full_url)
+        full_url = "http://example.com/path_to?foo=1"
+        request = self.fake_handler.make_request(
+            name="abc", method="GET", full_url=full_url
+        )
         self.assertEqual(request.url, full_url)
 
     def test_url_prefix_and_path(self):
-        url_prefix = 'example.com/path_to'
-        path = 'some/path/to/resource'
+        url_prefix = "example.com/path_to"
+        path = "some/path/to/resource"
         request = self.fake_handler.make_request(
-            name='abc',
-            method='GET',
-            url_prefix=url_prefix,
-            path=path)
+            name="abc", method="GET", url_prefix=url_prefix, path=path
+        )
 
-        self.assertEqual(request.url, 'http://{0}/{1}'.format(url_prefix, path))
+        self.assertEqual(request.url, "http://{0}/{1}".format(url_prefix, path))
 
     def test_url_prefix_without_path(self):
-        url_prefix = 'example.com/path_to'
+        url_prefix = "example.com/path_to"
         request = self.fake_handler.make_request(
-            name='abc',
-            method='GET',
-            url_prefix=url_prefix)
+            name="abc", method="GET", url_prefix=url_prefix
+        )
 
-        self.assertEqual(request.url, 'http://{0}'.format(url_prefix))
+        self.assertEqual(request.url, "http://{0}".format(url_prefix))
 
     def test_url_args_conflict(self):
         with self.assertRaises(TypeError):
             self.fake_handler.make_request(
-                name='abc',
-                method='GET',
-                url_prefix='example.com/path',
-                full_url='http://ex.com')
+                name="abc",
+                method="GET",
+                url_prefix="example.com/path",
+                full_url="http://ex.com",
+            )
 
     def test_empty_kwargs(self):
         with self.assertRaises(TypeError):
-            self.fake_handler.make_request('abc', 'GET')
+            self.fake_handler.make_request("abc", "GET")
 
     def test_unused_path_argument(self):
         with self.assertRaises(TypeError):
             self.fake_handler.make_request(
-                name='abc',
-                method='GET',
-                path='/path/to/resource',
-                full_url='http://ex.com')
+                name="abc",
+                method="GET",
+                path="/path/to/resource",
+                full_url="http://ex.com",
+            )
 
     def test_post_full_query(self):
-        full_url = 'http://example.com/path_to?foo=1'
-        request = self.fake_handler.make_request(name='abc', method='POST', full_url=full_url, data={'bar': 2})
+        full_url = "http://example.com/path_to?foo=1"
+        request = self.fake_handler.make_request(
+            name="abc", method="POST", full_url=full_url, data={"bar": 2}
+        )
         self.assertEqual(request.url, full_url)
-        self.assertEqual(request.body, b'bar=2')
+        self.assertEqual(request.body, b"bar=2")
 
     def test_post_full_query_raw(self):
-        full_url = 'http://example.com/path_to?foo=1'
+        full_url = "http://example.com/path_to?foo=1"
         data = b'{"json":true}'
-        request = self.fake_handler.make_request(name='abc', method='POST', full_url=full_url, data=data)
+        request = self.fake_handler.make_request(
+            name="abc", method="POST", full_url=full_url, data=data
+        )
         self.assertEqual(request.url, full_url)
         self.assertEqual(request.body, data)
 
     def test_post_query(self):
-        url_prefix = 'example.com'
-        path = '/path/to'
+        url_prefix = "example.com"
+        path = "/path/to"
         request = self.fake_handler.make_request(
-            name='abc',
-            method='POST',
-            url_prefix=url_prefix,
-            path=path,
-            data={'bar': 2}
+            name="abc", method="POST", url_prefix=url_prefix, path=path, data={"bar": 2}
         )
-        self.assertEqual(request.url, 'http://' + url_prefix + path)
-        self.assertEqual(request.body, b'bar=2')
+        self.assertEqual(request.url, "http://" + url_prefix + path)
+        self.assertEqual(request.body, b"bar=2")

--- a/tortik_tests/pep8_test.py
+++ b/tortik_tests/pep8_test.py
@@ -5,8 +5,11 @@ import unittest
 
 import pep8
 
-_project_root = path.abspath(path.join(path.dirname(__file__), '..'))
-_src_dirs = map(lambda x: path.join(_project_root, x), ['tortik', 'tortik_tests', 'examples', 'setup.py'])
+_project_root = path.abspath(path.join(path.dirname(__file__), ".."))
+_src_dirs = map(
+    lambda x: path.join(_project_root, x),
+    ["tortik", "tortik_tests", "examples", "setup.py"],
+)
 
 
 class Pep8TestCase(unittest.TestCase):
@@ -19,4 +22,6 @@ class Pep8TestCase(unittest.TestCase):
         )
         result = pep8style.check_files(_src_dirs)
 
-        self.assertEqual(result.total_errors, 0, 'Pep8 found code style errors or warnings')
+        self.assertEqual(
+            result.total_errors, 0, "Pep8 found code style errors or warnings"
+        )

--- a/tortik_tests/postprocessor_test.py
+++ b/tortik_tests/postprocessor_test.py
@@ -7,11 +7,11 @@ import tornado.curl_httpclient
 
 
 def first_postprocessor(handler, data, callback):
-    callback(handler, data.replace('Hello,', 'Good'))
+    callback(handler, data.replace("Hello,", "Good"))
 
 
 def second_postprocessor(handler, data, callback):
-    callback(handler, data.replace('Good world', 'Good bye'))
+    callback(handler, data.replace("Good world", "Good bye"))
 
 
 class MainHandler(RequestHandler):
@@ -21,13 +21,13 @@ class MainHandler(RequestHandler):
     ]
 
     def get(self):
-        self.complete('Hello, world!')
+        self.complete("Hello, world!")
 
 
 class Application(tornado.web.Application):
     def __init__(self):
         handlers = [
-            (r'/', MainHandler),
+            (r"/", MainHandler),
         ]
 
         settings = dict(
@@ -44,7 +44,7 @@ class PostprocessorHTTPTestCase(AsyncHTTPTestCase):
         return tornado.ioloop.IOLoop.instance()
 
     def test_main(self):
-        self.http_client.fetch(self.get_url('/'), self.stop)
+        self.http_client.fetch(self.get_url("/"), self.stop)
         response = self.wait()
         self.assertEqual(200, response.code)
-        self.assertIn(b'Good bye!', response.body)
+        self.assertIn(b"Good bye!", response.body)

--- a/tortik_tests/preprocessor_test.py
+++ b/tortik_tests/preprocessor_test.py
@@ -17,8 +17,11 @@ def first_preprocessor(handler, callback):
         callback()
 
     http_client = tornado.curl_httpclient.CurlAsyncHTTPClient()
-    http_client.fetch(handler.request.protocol + "://" + handler.request.host + '/mock/json',
-                      handle_request, request_timeout=0.2)
+    http_client.fetch(
+        handler.request.protocol + "://" + handler.request.host + "/mock/json",
+        handle_request,
+        request_timeout=0.2,
+    )
 
 
 def second_preprocessor(handler, callback):
@@ -27,8 +30,11 @@ def second_preprocessor(handler, callback):
         callback()
 
     http_client = tornado.curl_httpclient.CurlAsyncHTTPClient()
-    http_client.fetch(handler.request.protocol + "://" + handler.request.host + '/mock/json',
-                      handle_request, request_timeout=0.2)
+    http_client.fetch(
+        handler.request.protocol + "://" + handler.request.host + "/mock/json",
+        handle_request,
+        request_timeout=0.2,
+    )
 
 
 def third_preprocessor(handler, callback):
@@ -38,15 +44,11 @@ def third_preprocessor(handler, callback):
 
 
 class MainHandler(RequestHandler):
-    preprocessors = [
-        first_preprocessor,
-        second_preprocessor,
-        third_preprocessor
-    ]
+    preprocessors = [first_preprocessor, second_preprocessor, third_preprocessor]
 
     def get(self):
         if self.first and self.second and self.third:
-            self.complete({'status': 'ok'})
+            self.complete({"status": "ok"})
         else:
             raise tornado.web.HTTPError(500)
 
@@ -54,7 +56,7 @@ class MainHandler(RequestHandler):
 class MockJsonHandler(tornado.web.RequestHandler):
     @staticmethod
     def mock_data():
-        fd = open(os.path.join(os.path.dirname(__file__), 'data', 'simple.json'), 'r')
+        fd = open(os.path.join(os.path.dirname(__file__), "data", "simple.json"), "r")
         data = json_decode(fd.read())
         fd.close()
         return data
@@ -66,7 +68,7 @@ class MockJsonHandler(tornado.web.RequestHandler):
 class Application(tornado.web.Application):
     def __init__(self):
         handlers = [
-            (r'/', MainHandler),
+            (r"/", MainHandler),
             (r"/mock/json", MockJsonHandler),
         ]
 
@@ -84,7 +86,7 @@ class PreprocessorHTTPTestCase(AsyncHTTPTestCase):
         return tornado.ioloop.IOLoop.instance()
 
     def test_main(self):
-        self.http_client.fetch(self.get_url('/'), self.stop)
+        self.http_client.fetch(self.get_url("/"), self.stop)
         response = self.wait()
         self.assertEqual(200, response.code)
-        self.assertIn(b'ok', response.body)
+        self.assertIn(b"ok", response.body)

--- a/tortik_tests/runtests.py
+++ b/tortik_tests/runtests.py
@@ -20,15 +20,15 @@ except NameError:
     from functools import reduce  # py3
 
 TEST_MODULES = [
-    'tortik_tests.pep8_test',
-    'tortik_tests.import_test',
-    'tortik_tests.debug_test',
-    'tortik_tests.dumper_test',
-    'tortik_tests.exceptions_test',
-    'tortik_tests.make_request_test',
-    'tortik_tests.util_test',
-    'tortik_tests.postprocessor_test',
-    'tortik_tests.preprocessor_test',
+    "tortik_tests.pep8_test",
+    "tortik_tests.import_test",
+    "tortik_tests.debug_test",
+    "tortik_tests.dumper_test",
+    "tortik_tests.exceptions_test",
+    "tortik_tests.make_request_test",
+    "tortik_tests.util_test",
+    "tortik_tests.postprocessor_test",
+    "tortik_tests.preprocessor_test",
 ]
 
 
@@ -41,15 +41,19 @@ class TornadoTextTestRunner(unittest.TextTestRunner):
         result = super(TornadoTextTestRunner, self).run(test)
         if result.skipped:
             skip_reasons = set(reason for (test, reason) in result.skipped)
-            self.stream.write(textwrap.fill(
-                "Some tests were skipped because: %s" %
-                ", ".join(sorted(skip_reasons))))
+            self.stream.write(
+                textwrap.fill(
+                    "Some tests were skipped because: %s"
+                    % ", ".join(sorted(skip_reasons))
+                )
+            )
             self.stream.write("\n")
         return result
 
 
 class LogCounter(logging.Filter):
     """Counts the number of WARNING or higher log records."""
+
     def __init__(self, *args, **kwargs):
         # Can't use super() because logging.Filter is an old-style class in py26
         logging.Filter.__init__(self, *args, **kwargs)
@@ -68,6 +72,7 @@ def main():
     # python 3 (as of virtualenv 1.7), so configure warnings
     # programmatically instead.
     import warnings
+
     # Be strict about most warnings.  This also turns on warnings that are
     # ignored by default, including DeprecationWarnings and
     # python 3.2's ResourceWarnings.
@@ -78,59 +83,76 @@ def main():
     # Tornado generally shouldn't use anything deprecated, but some of
     # our dependencies do (last match wins).
     warnings.filterwarnings("ignore", category=DeprecationWarning)
-    warnings.filterwarnings("error", category=DeprecationWarning,
-                            module=r"tornado\..*")
+    warnings.filterwarnings("error", category=DeprecationWarning, module=r"tornado\..*")
     warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
-    warnings.filterwarnings("error", category=PendingDeprecationWarning,
-                            module=r"tornado\..*")
+    warnings.filterwarnings(
+        "error", category=PendingDeprecationWarning, module=r"tornado\..*"
+    )
     # The unittest module is aggressive about deprecating redundant methods,
     # leaving some without non-deprecated spellings that work on both
     # 2.7 and 3.2
-    warnings.filterwarnings("ignore", category=DeprecationWarning,
-                            message="Please use assert.* instead")
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="Please use assert.* instead"
+    )
     # unittest2 0.6 on py26 reports these as PendingDeprecationWarnings
     # instead of DeprecationWarnings.
-    warnings.filterwarnings("ignore", category=PendingDeprecationWarning,
-                            message="Please use assert.* instead")
+    warnings.filterwarnings(
+        "ignore",
+        category=PendingDeprecationWarning,
+        message="Please use assert.* instead",
+    )
     # Twisted 15.0.0 triggers some warnings on py3 with -bb.
-    warnings.filterwarnings("ignore", category=BytesWarning,
-                            module=r"twisted\..*")
+    warnings.filterwarnings("ignore", category=BytesWarning, module=r"twisted\..*")
 
     logging.getLogger("tornado.access").setLevel(logging.CRITICAL)
 
-    define('httpclient', type=str, default=None,
-           callback=lambda s: AsyncHTTPClient.configure(
-               s, defaults=dict(allow_ipv6=False)))
-    define('httpserver', type=str, default=None,
-           callback=HTTPServer.configure)
-    define('ioloop', type=str, default=None)
-    define('ioloop_time_monotonic', default=False)
-    define('resolver', type=str, default=None,
-           callback=Resolver.configure)
-    define('debug_gc', type=str, multiple=True,
-           help="A comma-separated list of gc module debug constants, "
-                "e.g. DEBUG_STATS or DEBUG_COLLECTABLE,DEBUG_OBJECTS",
-           callback=lambda values: gc.set_debug(
-               reduce(operator.or_, (getattr(gc, v) for v in values))))
-    define('locale', type=str, default=None,
-           callback=lambda x: locale.setlocale(locale.LC_ALL, x))
+    define(
+        "httpclient",
+        type=str,
+        default=None,
+        callback=lambda s: AsyncHTTPClient.configure(
+            s, defaults=dict(allow_ipv6=False)
+        ),
+    )
+    define("httpserver", type=str, default=None, callback=HTTPServer.configure)
+    define("ioloop", type=str, default=None)
+    define("ioloop_time_monotonic", default=False)
+    define("resolver", type=str, default=None, callback=Resolver.configure)
+    define(
+        "debug_gc",
+        type=str,
+        multiple=True,
+        help="A comma-separated list of gc module debug constants, "
+        "e.g. DEBUG_STATS or DEBUG_COLLECTABLE,DEBUG_OBJECTS",
+        callback=lambda values: gc.set_debug(
+            reduce(operator.or_, (getattr(gc, v) for v in values))
+        ),
+    )
+    define(
+        "locale",
+        type=str,
+        default=None,
+        callback=lambda x: locale.setlocale(locale.LC_ALL, x),
+    )
 
     def configure_ioloop():
         kwargs = {}
         if options.ioloop_time_monotonic:
             from tornado.platform.auto import monotonic_time
+
             if monotonic_time is None:
                 raise RuntimeError("monotonic clock not found")
-            kwargs['time_func'] = monotonic_time
+            kwargs["time_func"] = monotonic_time
         if options.ioloop or kwargs:
             IOLoop.configure(options.ioloop, **kwargs)
+
     add_parse_callback(configure_ioloop)
 
     log_counter = LogCounter()
-    add_parse_callback(
-        lambda: logging.getLogger().handlers[0].addFilter(log_counter))
+    add_parse_callback(lambda: logging.getLogger().handlers[0].addFilter(log_counter))
 
     import tornado.testing
+
     kwargs = {}
     if sys.version_info >= (3, 2):
         # HACK:  unittest.main will make its own changes to the warning
@@ -138,10 +160,11 @@ def main():
         # or command-line flags like -bb.  Passing warnings=False
         # suppresses this behavior, although this looks like an implementation
         # detail.  http://bugs.python.org/issue15626
-        kwargs['warnings'] = False
-    kwargs['testRunner'] = TornadoTextTestRunner
+        kwargs["warnings"] = False
+    kwargs["testRunner"] = TornadoTextTestRunner
 
     tornado.testing.main(**kwargs)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/tortik_tests/util_test.py
+++ b/tortik_tests/util_test.py
@@ -1,5 +1,6 @@
 # _*_ coding: utf-8 _*_
 import os
+
 try:
     from cStringIO import StringIO  # python 2
 except ImportError:
@@ -20,13 +21,13 @@ class Request(object):
 
 class BaseTest(unittest.TestCase):
     def assertQueriesEqual(self, qs1, qs2):
-        qs1_list = sorted(qs1.split('&'))
-        qs2_list = sorted(qs2.split('&'))
+        qs1_list = sorted(qs1.split("&"))
+        qs2_list = sorted(qs2.split("&"))
         self.assertEqual(qs1_list, qs2_list)
 
     def assertUrlsEqual(self, url1, url2):
-        u1 = url1.split('?')
-        u2 = url2.split('?')
+        u1 = url1.split("?")
+        u2 = url2.split("?")
 
         self.assertEqual(len(u1), len(u2))
         self.assertEqual(u1[0], u2[0])
@@ -35,104 +36,171 @@ class BaseTest(unittest.TestCase):
 
 
 class TestMakeQs(BaseTest):
-    """This is copy of Frontik's make_qs test: https://github.com/hhru/frontik/blob/master/tests/test_util.py
-    """
+    """This is copy of Frontik's make_qs test: https://github.com/hhru/frontik/blob/master/tests/test_util.py"""
+
     def test_make_qs_simple(self):
-        query_args = {'a': '1', 'b': '2'}
-        self.assertQueriesEqual(make_qs(query_args), 'a=1&b=2')
+        query_args = {"a": "1", "b": "2"}
+        self.assertQueriesEqual(make_qs(query_args), "a=1&b=2")
 
     def test_make_qs_not_str(self):
-        query_args = {'a': 1, 'b': 2.0, 'c': True}
-        self.assertQueriesEqual(make_qs(query_args), 'a=1&b=2.0&c=True')
+        query_args = {"a": 1, "b": 2.0, "c": True}
+        self.assertQueriesEqual(make_qs(query_args), "a=1&b=2.0&c=True")
 
     def test_make_qs_iterables(self):
-        query_args = {'a': [1, 2], 'b': {1, 2}, 'c': (1, 2), 'd': frozenset((1, 2))}
-        self.assertQueriesEqual(make_qs(query_args), 'a=1&a=2&b=1&b=2&c=1&c=2&d=1&d=2')
+        query_args = {"a": [1, 2], "b": {1, 2}, "c": (1, 2), "d": frozenset((1, 2))}
+        self.assertQueriesEqual(make_qs(query_args), "a=1&a=2&b=1&b=2&c=1&c=2&d=1&d=2")
 
     def test_make_qs_none(self):
-        query_args = {'a': None, 'b': None}
-        self.assertQueriesEqual(make_qs(query_args), '')
+        query_args = {"a": None, "b": None}
+        self.assertQueriesEqual(make_qs(query_args), "")
 
     def test_make_qs_encode(self):
-        query_args = {'a': u'тест', 'b': 'тест'}
+        query_args = {"a": "тест", "b": "тест"}
         qs = make_qs(query_args)
         self.assertIsInstance(qs, str)
-        self.assertQueriesEqual(qs, 'a=%D1%82%D0%B5%D1%81%D1%82&b=%D1%82%D0%B5%D1%81%D1%82')
+        self.assertQueriesEqual(
+            qs, "a=%D1%82%D0%B5%D1%81%D1%82&b=%D1%82%D0%B5%D1%81%D1%82"
+        )
 
     def test_from_ordered_dict(self):
-        qs = make_qs(OrderedDict([('z', 'я'), ('г', 'd'), ('b', ['2', '1'])]))
+        qs = make_qs(OrderedDict([("z", "я"), ("г", "d"), ("b", ["2", "1"])]))
         self.assertIsInstance(qs, str)
-        self.assertEqual(qs, 'z=%D1%8F&%D0%B3=d&b=2&b=1')
+        self.assertEqual(qs, "z=%D1%8F&%D0%B3=d&b=2&b=1")
 
     def test_unicode_params(self):
         self.assertQueriesEqual(
-            make_qs({'при': 'вет', u'по': u'ка'}),
-            '%D0%BF%D1%80%D0%B8=%D0%B2%D0%B5%D1%82&%D0%BF%D0%BE=%D0%BA%D0%B0'
+            make_qs({"при": "вет", "по": "ка"}),
+            "%D0%BF%D1%80%D0%B8=%D0%B2%D0%B5%D1%82&%D0%BF%D0%BE=%D0%BA%D0%B0",
         )
 
     def test_make_qs_comma(self):
-        query_args = {'a': '1,2,3', 'b': 'asd'}
-        self.assertQueriesEqual(make_qs(query_args, '/,'), 'a=1,2,3&b=asd')
+        query_args = {"a": "1,2,3", "b": "asd"}
+        self.assertQueriesEqual(make_qs(query_args, "/,"), "a=1,2,3&b=asd")
 
     def test_make_qs_comma_quoted(self):
         # default value for `safe` parameter of make_qs is '/' so commas
         # should be encoded
-        query_args = {'a': '1,2,3', 'b': 'asd'}
-        self.assertQueriesEqual(make_qs(query_args), 'a=1%2C2%2C3&b=asd')
+        query_args = {"a": "1,2,3", "b": "asd"}
+        self.assertQueriesEqual(make_qs(query_args), "a=1%2C2%2C3&b=asd")
 
 
 class TestUpdateUrl(BaseTest):
     def test_simple(self):
-        self.assertUrlsEqual(update_url('http://google.com'), 'http://google.com')
-        self.assertUrlsEqual(update_url('https://google.com'), 'https://google.com')
-        self.assertUrlsEqual(update_url('google.com'), 'google.com')
-        self.assertUrlsEqual(update_url('//google.com'), '//google.com')
-        self.assertUrlsEqual(update_url('http://google.com?a=1'), 'http://google.com?a=1')
-        self.assertUrlsEqual(update_url('http://google.com?a=1&b=2'), 'http://google.com?a=1&b=2')
-        self.assertUrlsEqual(update_url('http://google.com?привет=1'),
-                             'http://google.com?%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82=1')
-        self.assertUrlsEqual(update_url(u'http://google.com?привет=1'),
-                             'http://google.com?%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82=1')
+        self.assertUrlsEqual(update_url("http://google.com"), "http://google.com")
+        self.assertUrlsEqual(update_url("https://google.com"), "https://google.com")
+        self.assertUrlsEqual(update_url("google.com"), "google.com")
+        self.assertUrlsEqual(update_url("//google.com"), "//google.com")
+        self.assertUrlsEqual(
+            update_url("http://google.com?a=1"), "http://google.com?a=1"
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com?a=1&b=2"), "http://google.com?a=1&b=2"
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com?привет=1"),
+            "http://google.com?%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82=1",
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com?привет=1"),
+            "http://google.com?%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82=1",
+        )
 
     def test_update_args(self):
-        self.assertUrlsEqual(update_url('http://google.com', update_args={'a': 1}), 'http://google.com?a=1')
-        self.assertUrlsEqual(update_url('http://google.com', update_args={'a': '1'}), 'http://google.com?a=1')
-        self.assertUrlsEqual(update_url('http://google.com', update_args={'a': u'1'}), 'http://google.com?a=1')
-        self.assertUrlsEqual(update_url('http://google.com', update_args={u'a': u'1'}), 'http://google.com?a=1')
+        self.assertUrlsEqual(
+            update_url("http://google.com", update_args={"a": 1}),
+            "http://google.com?a=1",
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com", update_args={"a": "1"}),
+            "http://google.com?a=1",
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com", update_args={"a": "1"}),
+            "http://google.com?a=1",
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com", update_args={"a": "1"}),
+            "http://google.com?a=1",
+        )
 
-        self.assertUrlsEqual(update_url('http://google.com?a=2', update_args={'a': 1}), 'http://google.com?a=1')
-        self.assertUrlsEqual(update_url('http://google.com?a=2&b=1', update_args={'a': 1}), 'http://google.com?a=1&b=1')
+        self.assertUrlsEqual(
+            update_url("http://google.com?a=2", update_args={"a": 1}),
+            "http://google.com?a=1",
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com?a=2&b=1", update_args={"a": 1}),
+            "http://google.com?a=1&b=1",
+        )
 
     def test_remove_args(self):
-        self.assertUrlsEqual(update_url('http://google.com?a=2', remove_args=['a']), 'http://google.com')
-        self.assertUrlsEqual(update_url('http://google.com?a=2', remove_args=[u'a']), 'http://google.com')
-        self.assertUrlsEqual(update_url('http://google.com?привет=2', remove_args=['привет']), 'http://google.com')
-        self.assertUrlsEqual(update_url(u'http://google.com?привет=2', remove_args=[u'привет']), 'http://google.com')
-        self.assertUrlsEqual(update_url('http://google.com?a=2&a=1', remove_args=['a']), 'http://google.com')
-        self.assertUrlsEqual(update_url('http://google.com?a=2&a=1&b=3', remove_args=['a']), 'http://google.com?b=3')
-        self.assertUrlsEqual(update_url('http://google.com?a=2&a=1&b=3', remove_args=['b']),
-                             'http://google.com?a=2&a=1')
+        self.assertUrlsEqual(
+            update_url("http://google.com?a=2", remove_args=["a"]), "http://google.com"
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com?a=2", remove_args=["a"]), "http://google.com"
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com?привет=2", remove_args=["привет"]),
+            "http://google.com",
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com?привет=2", remove_args=["привет"]),
+            "http://google.com",
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com?a=2&a=1", remove_args=["a"]),
+            "http://google.com",
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com?a=2&a=1&b=3", remove_args=["a"]),
+            "http://google.com?b=3",
+        )
+        self.assertUrlsEqual(
+            update_url("http://google.com?a=2&a=1&b=3", remove_args=["b"]),
+            "http://google.com?a=2&a=1",
+        )
 
     def test_both(self):
-        self.assertUrlsEqual(update_url('http://google.com?b=3', update_args={'a': 1}, remove_args=['b']),
-                             'http://google.com?a=1')
-        self.assertUrlsEqual(update_url('http://google.com?a=2&b=3&c=4', update_args={'a': 1}, remove_args=['b']),
-                             'http://google.com?a=1&c=4')
+        self.assertUrlsEqual(
+            update_url(
+                "http://google.com?b=3", update_args={"a": 1}, remove_args=["b"]
+            ),
+            "http://google.com?a=1",
+        )
+        self.assertUrlsEqual(
+            update_url(
+                "http://google.com?a=2&b=3&c=4", update_args={"a": 1}, remove_args=["b"]
+            ),
+            "http://google.com?a=1&c=4",
+        )
 
 
 class TestParse(BaseTest):
     def test_parse_xml(self):
-        fd = open(os.path.join(os.path.dirname(__file__), 'data', 'simple.xml'), 'r')
+        fd = open(os.path.join(os.path.dirname(__file__), "data", "simple.xml"), "r")
         tree = parse(fd)
-        self.assertEqual(tree.getroot().tag, 'data')
-        convert = tostring(tree.getroot(), pretty_print=True, xml_declaration=True, encoding='UTF-8')
+        self.assertEqual(tree.getroot().tag, "data")
+        convert = tostring(
+            tree.getroot(), pretty_print=True, xml_declaration=True, encoding="UTF-8"
+        )
         # replace any possible conversion differences that are ok
         # Python 3+ native etree does not include xml declaration so we should remove it everywhere
-        converted = to_unicode(convert).replace('\n', '').replace(' ', '').replace('\'', '"').\
-            replace('<?xmlversion="1.0"encoding="UTF-8"?>', '').strip()
+        converted = (
+            to_unicode(convert)
+            .replace("\n", "")
+            .replace(" ", "")
+            .replace("'", '"')
+            .replace('<?xmlversion="1.0"encoding="UTF-8"?>', "")
+            .strip()
+        )
         fd.seek(0)
-        base = to_unicode(fd.read()).replace('\n', '').replace(' ', '').\
-            replace('<?xmlversion="1.0"encoding="UTF-8"?>', '').strip()
+        base = (
+            to_unicode(fd.read())
+            .replace("\n", "")
+            .replace(" ", "")
+            .replace('<?xmlversion="1.0"encoding="UTF-8"?>', "")
+            .strip()
+        )
         self.assertEqual(converted, base)
         fd.close()
 
@@ -141,19 +209,19 @@ class TestRealIp(BaseTest):
     def test_real_ip(self):
         # default
         request = Request()
-        self.assertEqual('127.0.0.1', real_ip(request))
+        self.assertEqual("127.0.0.1", real_ip(request))
 
         request = Request()
-        request.headers = {'X-Real-Ip': '8.8.8.8', 'X-Forwarded-For': '10.0.0.1'}
+        request.headers = {"X-Real-Ip": "8.8.8.8", "X-Forwarded-For": "10.0.0.1"}
 
-        self.assertEqual('10.0.0.1', real_ip(request))
-
-        request = Request()
-        request.headers = {'X-Forwarded-For': '10.0.0.1, 127.0.0.1'}
-
-        self.assertEqual('10.0.0.1', real_ip(request))
+        self.assertEqual("10.0.0.1", real_ip(request))
 
         request = Request()
-        request.headers = {'X-Real-Ip': '8.8.8.8'}
+        request.headers = {"X-Forwarded-For": "10.0.0.1, 127.0.0.1"}
 
-        self.assertEqual('8.8.8.8', real_ip(request))
+        self.assertEqual("10.0.0.1", real_ip(request))
+
+        request = Request()
+        request.headers = {"X-Real-Ip": "8.8.8.8"}
+
+        self.assertEqual("8.8.8.8", real_ip(request))


### PR DESCRIPTION
Сейчас в сентри ошибки улетают некорректно, каждая ошибка считается уникальной из-за того, что в логе вместо %s формируется итоговая строка заранее, сентри не может подобные ошибки сгруппировать.